### PR TITLE
fix: Allow Core to be null

### DIFF
--- a/src/AllowRequestMiddleware.php
+++ b/src/AllowRequestMiddleware.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class AllowRequestMiddleware
 {
-    public function __construct(private Core $core)
+    public function __construct(private ?Core $core)
     {
     }
 


### PR DESCRIPTION
When Wafris is disabled, the Core class is resolved to `null`: https://github.com/Wafris/laravel-wafris/blob/main/src/WafrisServiceProvider.php#L17

This causes the `AllowRequestMiddleware` class constructor to fail, because it expects the `Core` type to be resolved. By adding questions mark, we allow `Core` to be nullable.

<img width="1059" alt="Screenshot 2024-03-01 at 10 38 39" src="https://github.com/Wafris/laravel-wafris/assets/220535/5ecf835a-7215-4f20-b82f-bede48ce35bd">
